### PR TITLE
Fix block assembly and verification

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -76,7 +76,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ad1126cf04461e48707815cc47ac11262dbe20bca43d63226a7e5e62049a9a32"
+  digest = "1:fd370ed3e5c1ca8c79d3221bfd8fe37ab9b8a03ac103be3933068d90f741f837"
   name = "github.com/SmartBFT-Go/consensus"
   packages = [
     "internal/bft",
@@ -87,7 +87,7 @@
     "smartbftprotos",
   ]
   pruneopts = "NUT"
-  revision = "38345f8fa525bfb37c628e2805a08eb797a88fa3"
+  revision = "2476d075055838aaab43075398e8544e845d05f8"
 
 [[projects]]
   branch = "master"

--- a/orderer/common/multichannel/blockwriter.go
+++ b/orderer/common/multichannel/blockwriter.go
@@ -182,10 +182,7 @@ func (bw *BlockWriter) commitBlock(encodedMetadataValue []byte) {
 	if encodedMetadataValue != nil {
 		bw.lastBlock.Metadata.Metadata[cb.BlockMetadataIndex_ORDERER] = protoutil.MarshalOrPanic(&cb.Metadata{Value: encodedMetadataValue})
 	}
-
-	if bw.lastBlock.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG] == nil {
-		bw.addLastConfigSignature(bw.lastBlock)
-	}
+	bw.addLastConfigSignature(bw.lastBlock)
 	if bw.lastBlock.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES] == nil {
 		bw.addBlockSignature(bw.lastBlock)
 	}

--- a/orderer/consensus/smartbft/assembler.go
+++ b/orderer/consensus/smartbft/assembler.go
@@ -55,11 +55,17 @@ func (a *Assembler) AssembleProposal(metadata []byte, requests [][]byte) (nextPr
 		A: protoutil.MarshalOrPanic(block.Data),
 		B: protoutil.MarshalOrPanic(block.Metadata),
 	}
+
+	configEnvelope, err := ConfigurationEnvelop(lastConfigBlock)
+	if err != nil {
+		a.Logger.Panicf("Failed to extract configuration envelope of last config block,err %s", err)
+	}
+
 	prop := types.Proposal{
 		Header:               protoutil.MarshalOrPanic(block.Header),
 		Payload:              tuple.ToBytes(),
 		Metadata:             metadata,
-		VerificationSequence: int64(lastConfigBlock.Header.Number),
+		VerificationSequence: int64(configEnvelope.Config.Sequence),
 	}
 
 	return prop, requests[len(batchedRequests):]

--- a/orderer/consensus/smartbft/assembler_test.go
+++ b/orderer/consensus/smartbft/assembler_test.go
@@ -129,7 +129,15 @@ func makeConfigBlock(seq uint64) *common.Block {
 			Number: seq,
 		},
 		Data: &common.BlockData{
-			Data: [][]byte{configTx},
+			Data: [][]byte{protoutil.MarshalOrPanic(&common.Envelope{
+				Payload: protoutil.MarshalOrPanic(&common.Payload{
+					Data: protoutil.MarshalOrPanic(&common.ConfigEnvelope{
+						Config: &common.Config{
+							Sequence: 10,
+						},
+					}),
+				}),
+			})},
 		},
 		Metadata: &common.BlockMetadata{
 			Metadata: [][]byte{{},

--- a/orderer/consensus/smartbft/chain.go
+++ b/orderer/consensus/smartbft/chain.go
@@ -176,6 +176,7 @@ func (c *BFTChain) Start() {
 			policyManager: c.PolicyManager,
 			Logger:        c.Logger,
 		},
+		Ledger: c.support,
 	}
 
 	if c.verifier.LastCommittedBlockHash == "" {

--- a/orderer/consensus/smartbft/util.go
+++ b/orderer/consensus/smartbft/util.go
@@ -14,6 +14,7 @@ import (
 	"github.com/SmartBFT-Go/consensus/pkg/types"
 	"github.com/SmartBFT-Go/consensus/smartbftprotos"
 	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/common/configtx"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/orderer/common/cluster"
 	"github.com/hyperledger/fabric/orderer/common/localconfig"
@@ -150,4 +151,23 @@ func (ri *RequestInspector) unwrapReq(req []byte) (*request, error) {
 		sigHdr:   sigHdr,
 		envelope: envelope,
 	}, nil
+}
+
+// ConfigurationEnvelop extract configuration envelop
+func ConfigurationEnvelop(configBlock *common.Block) (*common.ConfigEnvelope, error) {
+	envelopeConfig, err := protoutil.ExtractEnvelope(configBlock, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to extract envelop from block")
+	}
+
+	payload, err := protoutil.UnmarshalPayload(envelopeConfig.Payload)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal envelop payload")
+	}
+
+	configEnvelope, err := configtx.UnmarshalConfigEnvelope(payload.Data)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal configuration payload")
+	}
+	return configEnvelope, nil
 }

--- a/vendor/github.com/SmartBFT-Go/consensus/internal/bft/controller.go
+++ b/vendor/github.com/SmartBFT-Go/consensus/internal/bft/controller.go
@@ -107,6 +107,16 @@ func (c *Controller) leaderID() uint64 {
 	return c.getCurrentViewNumber() % c.N
 }
 
+// computeQuorum calculates the quorums size Q, given a cluster size N.
+//
+// The calculation satisfies the following:
+// Given a cluster size of N nodes, which tolerates f failures according to:
+//    f = argmax ( N >= 3f+1 )
+// Q is the size of the quorum such that:
+//    any two subsets q1, q2 of size Q, intersect in at least f+1 nodes.
+//
+// Note that this is different from N-f (the number of correct nodes), when N=3f+3. That is, we have two extra nodes
+// above the minimum required to tolerate f failures.
 func (c *Controller) computeQuorum() int {
 	f := int((int(c.N) - 1) / 3)
 	q := int(math.Ceil((float64(c.N) + float64(f) + 1) / 2.0))
@@ -389,7 +399,7 @@ func (c *Controller) Decide(proposal types.Proposal, signatures []types.Signatur
 		requests:   requests,
 		signatures: signatures,
 	}
-	<-c.decisionChan
+	<-c.decisionChan //TODO this a confusing pattern, replace with a "Future" or another channel.
 }
 
 func (c *Controller) deliverToApplication(d decision) {

--- a/vendor/github.com/SmartBFT-Go/consensus/internal/bft/view.go
+++ b/vendor/github.com/SmartBFT-Go/consensus/internal/bft/view.go
@@ -78,7 +78,7 @@ type View struct {
 	abortChan chan struct{}
 }
 
-func (v *View) Start() Future {
+func (v *View) Start() Future { //TODO the future should be return by Close() or implemented by View itself
 	v.incMsgs = make(chan *incMsg, 10*v.N) // TODO channel size should be configured
 	v.abortChan = make(chan struct{})
 
@@ -245,7 +245,7 @@ func (v *View) doPhase() {
 		v.Comm.BroadcastConsensus(v.lastBroadcastSent)
 		v.Phase = v.prepared()
 	default:
-		v.Phase = v.processProposal()
+		v.Phase = v.processProposal() //TODO address all phases explicitly, and panic on default
 	}
 }
 
@@ -375,7 +375,7 @@ func (v *View) processPrepares() Phase {
 				Signature: &protos.Signature{
 					Signer: v.myProposalSig.Id,
 					Value:  v.myProposalSig.Value,
-					Msg:    v.myProposalSig.Msg,
+					Msg:    v.myProposalSig.Msg, // TODO this contains the proposal, check whether we need this, because it will be broadcast by all: O(N^2)
 				},
 			},
 		},


### PR DESCRIPTION
While assembling block need to pass into proposal verification sequence,
which is the sequence of the last configuration update. Consequently
while verifying proposal need to check against last configuration and
last config update transaction and not to count on the block sequence.
Moreover while writting block into ledger need to update last config
block metadata in case current block is configuration.

Change-Id: I0453dc83cb46faf50a6a27ddbb3553a74d356cd6
Signed-off-by: Artem Barger <bartem@il.ibm.com>