### PR TITLE
Bug Fix: Sync: ConfigSqn instead of ConfigBlockNum

### DIFF
--- a/orderer/consensus/smartbft/util.go
+++ b/orderer/consensus/smartbft/util.go
@@ -88,17 +88,6 @@ func getViewMetadataFromBlock(block *common.Block) (smartbftprotos.ViewMetadata,
 	return viewMetadata, nil
 }
 
-func getViewMetadataLastConfigSqnFromBlock(block *common.Block) (smartbftprotos.ViewMetadata, uint64) {
-	viewMetadata, err := getViewMetadataFromBlock(block)
-	if err != nil {
-		return smartbftprotos.ViewMetadata{}, 0
-	}
-
-	sqn := protoutil.GetLastConfigIndexFromBlockOrPanic(block)
-
-	return viewMetadata, sqn
-}
-
 // RequestInspector inspects incomming requests and validates serialized identity
 type RequestInspector struct {
 	ValidateIdentityStructure func(identity *msp.SerializedIdentity) error


### PR DESCRIPTION
Bug fix: in Sync, return the last block ConfigSqn, instead of
last config block number.

Change-Id: Ib410469ff7244ec83c88840f79f49c3b5186df39
Signed-off-by: Yoav Tock <tock@il.ibm.com>