### PR TITLE
Byz client: Gossip api crypto verify block header

### DIFF
--- a/core/deliverservice/blocksprovider/blocksprovider_test.go
+++ b/core/deliverservice/blocksprovider/blocksprovider_test.go
@@ -46,6 +46,14 @@ func (m *mockMCS) VerifyBlock(chainID common2.ChainID, seqNum uint64, signedBloc
 	return nil
 }
 
+func (m *mockMCS) VerifyHeader(chainID common2.ChainID, seqNum uint64, signedBlock *common.Block) error {
+	args := m.Called()
+	if args.Get(0) != nil {
+		return args.Get(0).(error)
+	}
+	return nil
+}
+
 func (*mockMCS) Sign(msg []byte) ([]byte, error) {
 	return msg, nil
 }

--- a/core/deliverservice/deliveryclient_test.go
+++ b/core/deliverservice/deliveryclient_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/fabric/gossip/api"
 	"github.com/hyperledger/fabric/gossip/common"
 	msptesttools "github.com/hyperledger/fabric/msp/mgmt/testtools"
+	common2 "github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/orderer"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -60,6 +61,10 @@ func (*mockMCS) GetPKIidOfCert(peerIdentity api.PeerIdentityType) common.PKIidTy
 }
 
 func (*mockMCS) VerifyBlock(chainID common.ChainID, seqNum uint64, signedBlock []byte) error {
+	return nil
+}
+
+func (*mockMCS) VerifyHeader(chainID common.ChainID, seqNum uint64, signedBlock *common2.Block) error {
 	return nil
 }
 

--- a/gossip/api/crypto.go
+++ b/gossip/api/crypto.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hyperledger/fabric/gossip/common"
+	protoscommon "github.com/hyperledger/fabric/protos/common"
 	"google.golang.org/grpc"
 )
 
@@ -28,6 +29,10 @@ type MessageCryptoService interface {
 	// sequence number that the block's header contains.
 	// else returns error
 	VerifyBlock(chainID common.ChainID, seqNum uint64, signedBlock []byte) error
+
+	// VerifyHeader does the same as VerifyBlock, except it does not compute the block.Data.Hash() and compare it to
+	// the block.Header.DataHash. This is used when the orderer delivers a block with header & metadata only.
+	VerifyHeader(chainID common.ChainID, seqNum uint64, signedBlock *protoscommon.Block) error
 
 	// Sign signs msg with this peer's signing key and outputs
 	// the signature if no error occurred.

--- a/gossip/comm/comm_test.go
+++ b/gossip/comm/comm_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	common2 "github.com/hyperledger/fabric/protos/common"
+
 	"github.com/hyperledger/fabric/bccsp/factory"
 	"github.com/hyperledger/fabric/common/metrics/disabled"
 	"github.com/hyperledger/fabric/core/comm"
@@ -89,6 +91,10 @@ func (*naiveSecProvider) GetPKIidOfCert(peerIdentity api.PeerIdentityType) commo
 // VerifyBlock returns nil if the block is properly signed,
 // else returns error
 func (*naiveSecProvider) VerifyBlock(chainID common.ChainID, seqNum uint64, signedBlock []byte) error {
+	return nil
+}
+
+func (*naiveSecProvider) VerifyHeader(chainID common.ChainID, seqNum uint64, signedBlock *common2.Block) error {
 	return nil
 }
 

--- a/gossip/gossip/channel/channel_test.go
+++ b/gossip/gossip/channel/channel_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hyperledger/fabric/gossip/metrics"
 	"github.com/hyperledger/fabric/gossip/metrics/mocks"
 	"github.com/hyperledger/fabric/gossip/util"
+	protoscommon "github.com/hyperledger/fabric/protos/common"
 	proto "github.com/hyperledger/fabric/protos/gossip"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -139,6 +140,10 @@ func (cs *cryptoService) VerifyBlock(chainID common.ChainID, seqNum uint64, sign
 		return nil
 	}
 	return args.Get(0).(error)
+}
+
+func (cs *cryptoService) VerifyHeader(chainID common.ChainID, seqNum uint64, signedBlock *protoscommon.Block) error {
+	panic("Should not be called in this test")
 }
 
 func (cs *cryptoService) Sign(msg []byte) ([]byte, error) {

--- a/gossip/gossip/gossip_test.go
+++ b/gossip/gossip/gossip_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	common2 "github.com/hyperledger/fabric/protos/common"
+
 	"github.com/hyperledger/fabric/bccsp/factory"
 	"github.com/hyperledger/fabric/common/metrics/disabled"
 	corecomm "github.com/hyperledger/fabric/core/comm"
@@ -191,6 +193,10 @@ func (*naiveCryptoService) GetPKIidOfCert(peerIdentity api.PeerIdentityType) com
 // VerifyBlock returns nil if the block is properly signed,
 // else returns error
 func (*naiveCryptoService) VerifyBlock(chainID common.ChainID, seqNum uint64, signedBlock []byte) error {
+	return nil
+}
+
+func (*naiveCryptoService) VerifyHeader(chainID common.ChainID, seqNum uint64, signedBlock *common2.Block) error {
 	return nil
 }
 

--- a/gossip/gossip/orgs_test.go
+++ b/gossip/gossip/orgs_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hyperledger/fabric/gossip/gossip/channel"
 	"github.com/hyperledger/fabric/gossip/metrics"
 	"github.com/hyperledger/fabric/gossip/util"
+	protoscommon "github.com/hyperledger/fabric/protos/common"
 	proto "github.com/hyperledger/fabric/protos/gossip"
 	"github.com/stretchr/testify/assert"
 )
@@ -71,6 +72,10 @@ func (*configurableCryptoService) GetPKIidOfCert(peerIdentity api.PeerIdentityTy
 // VerifyBlock returns nil if the block is properly signed,
 // else returns error
 func (*configurableCryptoService) VerifyBlock(chainID common.ChainID, seqNum uint64, signedBlock []byte) error {
+	return nil
+}
+
+func (*configurableCryptoService) VerifyHeader(chainID common.ChainID, seqNum uint64, signedBlock *protoscommon.Block) error {
 	return nil
 }
 

--- a/gossip/identity/identity_test.go
+++ b/gossip/identity/identity_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	common2 "github.com/hyperledger/fabric/protos/common"
+
 	"github.com/hyperledger/fabric/gossip/api"
 	"github.com/hyperledger/fabric/gossip/common"
 	"github.com/hyperledger/fabric/gossip/util"
@@ -78,6 +80,10 @@ func (*naiveCryptoService) GetPKIidOfCert(peerIdentity api.PeerIdentityType) com
 // VerifyBlock returns nil if the block is properly signed,
 // else returns error
 func (*naiveCryptoService) VerifyBlock(chainID common.ChainID, seqNum uint64, signedBlock []byte) error {
+	return nil
+}
+
+func (*naiveCryptoService) VerifyHeader(chainID common.ChainID, seqNum uint64, signedBlock *common2.Block) error {
 	return nil
 }
 

--- a/gossip/integration/integration_test.go
+++ b/gossip/integration/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hyperledger/fabric/gossip/util"
 	"github.com/hyperledger/fabric/msp/mgmt"
 	"github.com/hyperledger/fabric/msp/mgmt/testtools"
+	protoscommon "github.com/hyperledger/fabric/protos/common"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -103,6 +104,10 @@ func (s *cryptoService) GetPKIidOfCert(peerIdentity api.PeerIdentityType) common
 }
 
 func (s *cryptoService) VerifyBlock(chainID common.ChainID, seqNum uint64, signedBlock []byte) error {
+	return nil
+}
+
+func (s *cryptoService) VerifyHeader(chainID common.ChainID, seqNum uint64, signedBlock *protoscommon.Block) error {
 	return nil
 }
 

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -806,6 +806,10 @@ func (*naiveCryptoService) VerifyBlock(chainID gossipCommon.ChainID, seqNum uint
 	return nil
 }
 
+func (*naiveCryptoService) VerifyHeader(chainID gossipCommon.ChainID, seqNum uint64, signedBlock *common.Block) error {
+	return nil
+}
+
 // Sign signs msg with this peer's signing key and outputs
 // the signature if no error occurred.
 func (*naiveCryptoService) Sign(msg []byte) ([]byte, error) {

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -130,6 +130,10 @@ func (*cryptoServiceMock) VerifyBlock(chainID common.ChainID, seqNum uint64, sig
 	return nil
 }
 
+func (*cryptoServiceMock) VerifyHeader(chainID common.ChainID, seqNum uint64, signedBlock *pcomm.Block) error {
+	return nil
+}
+
 // Sign signs msg with this peer's signing key and outputs
 // the signature if no error occurred.
 func (*cryptoServiceMock) Sign(msg []byte) ([]byte, error) {

--- a/peer/gossip/mcs.go
+++ b/peer/gossip/mcs.go
@@ -133,7 +133,7 @@ func (s *MSPMessageCryptoService) VerifyBlock(chainID common.ChainID, seqNum uin
 		return fmt.Errorf("Invalid block's channel id. Expected [%s]. Given [%s]", chainID, channelID)
 	}
 
-	// - Unmarshal medatada
+	// - Unmarshal metadata
 	if block.Metadata == nil || len(block.Metadata.Metadata) == 0 {
 		return fmt.Errorf("Block with id [%d] on channel [%s] does not have metadata. Block not valid.", block.Header.Number, chainID)
 	}
@@ -149,8 +149,10 @@ func (s *MSPMessageCryptoService) VerifyBlock(chainID common.ChainID, seqNum uin
 		return fmt.Errorf("Header.DataHash is different from Hash(block.Data) for block with id [%d] on channel [%s]", block.Header.Number, chainID)
 	}
 
-	// - Get Policy for block validation
+	return s.verifyHeaderWithMetadata(channelID, block.Header, metadata)
+}
 
+func (s *MSPMessageCryptoService) verifyHeaderWithMetadata(channelID string, header *pcommon.BlockHeader, metadata *pcommon.Metadata) error {
 	// Get the policy manager for channelID
 	cpm, ok := s.channelPolicyManagerGetter.Manager(channelID)
 	if cpm == nil {
@@ -169,13 +171,13 @@ func (s *MSPMessageCryptoService) VerifyBlock(chainID common.ChainID, seqNum uin
 	for _, metadataSignature := range metadata.Signatures {
 		shdr, err := utils.GetSignatureHeader(metadataSignature.SignatureHeader)
 		if err != nil {
-			return fmt.Errorf("Failed unmarshalling signature header for block with id [%d] on channel [%s]: [%s]", block.Header.Number, chainID, err)
+			return fmt.Errorf("Failed unmarshalling signature header for block with id [%d] on channel [%s]: [%s]", header.Number, channelID, err)
 		}
 		signatureSet = append(
 			signatureSet,
 			&pcommon.SignedData{
 				Identity:  shdr.Creator,
-				Data:      util.ConcatenateBytes(metadata.Value, metadataSignature.SignatureHeader, block.Header.Bytes()),
+				Data:      util.ConcatenateBytes(metadata.Value, metadataSignature.SignatureHeader, header.Bytes()),
 				Signature: metadataSignature.Signature,
 			},
 		)
@@ -183,6 +185,33 @@ func (s *MSPMessageCryptoService) VerifyBlock(chainID common.ChainID, seqNum uin
 
 	// - Evaluate policy
 	return policy.Evaluate(signatureSet)
+}
+
+func (s *MSPMessageCryptoService) VerifyHeader(chainID common.ChainID, seqNum uint64, block *pcommon.Block) error {
+	if block == nil {
+		return fmt.Errorf("Invalid Block on channel [%s]. Block is nil.", chainID)
+	}
+
+	if block.Header == nil {
+		return fmt.Errorf("Invalid Block on channel [%s]. Header must be different from nil.", chainID)
+	}
+
+	blockSeqNum := block.Header.Number
+	if seqNum != blockSeqNum {
+		return fmt.Errorf("Claimed seqNum is [%d] but actual seqNum inside block is [%d]", seqNum, blockSeqNum)
+	}
+
+	// - Unmarshal metadata
+	if block.Metadata == nil || len(block.Metadata.Metadata) == 0 {
+		return fmt.Errorf("Block with id [%d] on channel [%s] does not have metadata. Block not valid.", block.Header.Number, chainID)
+	}
+
+	metadata, err := utils.GetMetadataFromBlock(block, pcommon.BlockMetadataIndex_SIGNATURES)
+	if err != nil {
+		return fmt.Errorf("Failed unmarshalling medatata for signatures [%s]", err)
+	}
+
+	return s.verifyHeaderWithMetadata(string(chainID), block.Header, metadata)
 }
 
 // Sign signs msg with this peer's signing key and outputs

--- a/peer/gossip/mcs_test.go
+++ b/peer/gossip/mcs_test.go
@@ -185,20 +185,21 @@ func TestVerify(t *testing.T) {
 
 func TestVerifyBlock(t *testing.T) {
 	aliceSigner := &mockscrypto.LocalSigner{Identity: []byte("Alice")}
+	managerD := &mocks.ChannelPolicyManager{
+		Policy: &mocks.Policy{Deserializer: &mocks.IdentityDeserializer{Identity: []byte("Alice"), Msg: []byte("msg1"), Mock: mock.Mock{}}},
+	}
 	policyManagerGetter := &mocks.ChannelPolicyManagerGetterWithManager{
 		Managers: map[string]policies.Manager{
 			"A": &mocks.ChannelPolicyManager{
 				Policy: &mocks.Policy{Deserializer: &mocks.IdentityDeserializer{Identity: []byte("Bob"), Msg: []byte("msg2"), Mock: mock.Mock{}}},
 			},
 			"B": &mocks.ChannelPolicyManager{
-				Policy: &mocks.Policy{Deserializer: &mocks.IdentityDeserializer{Identity: []byte("Charlie"), Msg: []byte("msg3"), Mock: mock.Mock{}}},
+				Policy: &mocks.Policy{Deserializer: &mocks.IdentityDeserializer{Identity: []byte("Charlie"), Msg: []byte("msgInvalid"), Mock: mock.Mock{}}},
 			},
 			"C": &mocks.ChannelPolicyManager{
 				Policy: &mocks.Policy{Deserializer: &mocks.IdentityDeserializer{Identity: []byte("Alice"), Msg: []byte("msg1"), Mock: mock.Mock{}}},
 			},
-			"D": &mocks.ChannelPolicyManager{
-				Policy: &mocks.Policy{Deserializer: &mocks.IdentityDeserializer{Identity: []byte("Alice"), Msg: []byte("msg1"), Mock: mock.Mock{}}},
-			},
+			"D": managerD,
 		},
 	}
 
@@ -219,30 +220,76 @@ func TestVerifyBlock(t *testing.T) {
 	policyManagerGetter.Managers["C"].(*mocks.ChannelPolicyManager).Policy.(*mocks.Policy).Deserializer.(*mocks.IdentityDeserializer).Msg = msg
 	blockRaw2, msg2 := mockBlock(t, "D", 42, aliceSigner, nil)
 	policyManagerGetter.Managers["D"].(*mocks.ChannelPolicyManager).Policy.(*mocks.Policy).Deserializer.(*mocks.IdentityDeserializer).Msg = msg2
+	_, msgInvalid := mockBlock(t, "C", 42, aliceSigner, []byte{0})
 
-	// - Verify block
-	assert.NoError(t, msgCryptoService.VerifyBlock([]byte("C"), 42, blockRaw))
-	// Wrong sequence number claimed
-	err := msgCryptoService.VerifyBlock([]byte("C"), 43, blockRaw)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "but actual seqNum inside block is")
-	delete(policyManagerGetter.Managers, "D")
-	nilPolMgrErr := msgCryptoService.VerifyBlock([]byte("D"), 42, blockRaw2)
-	assert.Contains(t, nilPolMgrErr.Error(), "Could not acquire policy manager")
-	assert.Error(t, nilPolMgrErr)
-	assert.Error(t, msgCryptoService.VerifyBlock([]byte("A"), 42, blockRaw))
-	assert.Error(t, msgCryptoService.VerifyBlock([]byte("B"), 42, blockRaw))
+	t.Run("verify block", func(t *testing.T) {
+		// - Verify block
+		assert.NoError(t, msgCryptoService.VerifyBlock([]byte("C"), 42, blockRaw))
+		// Wrong sequence number claimed
+		err := msgCryptoService.VerifyBlock([]byte("C"), 43, blockRaw)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "but actual seqNum inside block is")
+		delete(policyManagerGetter.Managers, "D")
+		nilPolMgrErr := msgCryptoService.VerifyBlock([]byte("D"), 42, blockRaw2)
+		assert.Contains(t, nilPolMgrErr.Error(), "Could not acquire policy manager")
+		assert.Error(t, nilPolMgrErr)
+		assert.Error(t, msgCryptoService.VerifyBlock([]byte("A"), 42, blockRaw))
+		assert.Error(t, msgCryptoService.VerifyBlock([]byte("B"), 42, blockRaw))
 
-	// - Prepare testing invalid block (wrong data has), Alice signs it.
-	blockRaw, msg = mockBlock(t, "C", 42, aliceSigner, []byte{0})
-	policyManagerGetter.Managers["C"].(*mocks.ChannelPolicyManager).Policy.(*mocks.Policy).Deserializer.(*mocks.IdentityDeserializer).Msg = msg
+		// - Prepare testing invalid block (wrong data has), Alice signs it.
+		policyManagerGetter.Managers["C"].(*mocks.ChannelPolicyManager).Policy.(*mocks.Policy).Deserializer.(*mocks.IdentityDeserializer).Msg = msgInvalid
+		// - Verify block
+		assert.Error(t, msgCryptoService.VerifyBlock([]byte("C"), 42, blockRaw))
 
-	// - Verify block
-	assert.Error(t, msgCryptoService.VerifyBlock([]byte("C"), 42, blockRaw))
+		// Check invalid args
+		assert.Error(t, msgCryptoService.VerifyBlock([]byte("C"), 42, []byte{0, 1, 2, 3, 4}))
+		assert.Error(t, msgCryptoService.VerifyBlock([]byte("C"), 42, nil))
 
-	// Check invalid args
-	assert.Error(t, msgCryptoService.VerifyBlock([]byte("C"), 42, []byte{0, 1, 2, 3, 4}))
-	assert.Error(t, msgCryptoService.VerifyBlock([]byte("C"), 42, nil))
+		policyManagerGetter.Managers["D"] = managerD
+		policyManagerGetter.Managers["C"].(*mocks.ChannelPolicyManager).Policy.(*mocks.Policy).Deserializer.(*mocks.IdentityDeserializer).Msg = msg
+	})
+
+	t.Run("verify header", func(t *testing.T) {
+		block, err := utils.GetBlockFromBlockBytes(blockRaw)
+		assert.NoError(t, err)
+		block.Data = nil
+
+		block2, err := utils.GetBlockFromBlockBytes(blockRaw2)
+		assert.NoError(t, err)
+		block2.Data = nil
+
+		// - Verify block
+		assert.NoError(t, msgCryptoService.VerifyHeader([]byte("C"), 42, block))
+		// Wrong sequence number claimed
+		err = msgCryptoService.VerifyHeader([]byte("C"), 43, block)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "but actual seqNum inside block is")
+		delete(policyManagerGetter.Managers, "D")
+		nilPolMgrErr := msgCryptoService.VerifyHeader([]byte("D"), 42, block2)
+		assert.Contains(t, nilPolMgrErr.Error(), "Could not acquire policy manager")
+		assert.Error(t, nilPolMgrErr)
+		assert.Error(t, msgCryptoService.VerifyHeader([]byte("A"), 42, block))
+		assert.Error(t, msgCryptoService.VerifyHeader([]byte("B"), 42, block))
+
+		// - Prepare testing invalid block (wrong data has), Alice signs it.
+		policyManagerGetter.Managers["C"].(*mocks.ChannelPolicyManager).Policy.(*mocks.Policy).Deserializer.(*mocks.IdentityDeserializer).Msg = msgInvalid
+
+		// - Verify block
+		assert.Error(t, msgCryptoService.VerifyHeader([]byte("C"), 42, block))
+
+		// Check invalid args
+		block.Header.DataHash = []byte{0, 1, 2, 3, 4}
+		assert.Error(t, msgCryptoService.VerifyHeader([]byte("C"), 42, block))
+		block.Metadata = nil
+		assert.Error(t, msgCryptoService.VerifyHeader([]byte("C"), 42, block))
+		block.Header = nil
+		assert.Error(t, msgCryptoService.VerifyHeader([]byte("C"), 42, block))
+		assert.Error(t, msgCryptoService.VerifyHeader([]byte("C"), 42, nil))
+
+		policyManagerGetter.Managers["D"] = managerD
+		policyManagerGetter.Managers["C"].(*mocks.ChannelPolicyManager).Policy.(*mocks.Policy).Deserializer.(*mocks.IdentityDeserializer).Msg = msg
+	})
+
 }
 
 func mockBlock(t *testing.T, channel string, seqNum uint64, localSigner crypto.LocalSigner, dataHash []byte) ([]byte, []byte) {


### PR DESCRIPTION
Add a method that verifies the signature vs. header on
blocks with Data=nil.

Change-Id: Ifc3bc9490f45517d82cfdbe18d498f610fb7e2fc
Signed-off-by: Yoav Tock <tock@il.ibm.com>