### PR TITLE
Use last config from signature orderer block metadata

### DIFF
--- a/orderer/common/cluster/deliver_test.go
+++ b/orderer/common/cluster/deliver_test.go
@@ -244,9 +244,17 @@ func (ds *deliverServer) stop() {
 }
 
 func (ds *deliverServer) enqueueResponse(seq uint64) {
-	ds.blocks() <- &orderer.DeliverResponse{
+	block := &orderer.DeliverResponse{
 		Type: &orderer.DeliverResponse_Block{Block: common.NewBlock(seq, nil)},
 	}
+	block.GetBlock().Metadata.Metadata[common.BlockMetadataIndex_SIGNATURES] = utils.MarshalOrPanic(&common.Metadata{
+		Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{
+			LastConfig: &common.LastConfig{
+				Index: seq - 1,
+			},
+		}),
+	})
+	ds.blocks() <- block
 }
 
 func (ds *deliverServer) addExpectProbeAssert() {

--- a/orderer/common/cluster/replication.go
+++ b/orderer/common/cluster/replication.go
@@ -520,7 +520,7 @@ func latestHeightAndEndpoint(puller ChainPuller) (string, uint64, error) {
 }
 
 func lastConfigFromBlock(block *common.Block) (uint64, error) {
-	if block.Metadata == nil || len(block.Metadata.Metadata) <= int(common.BlockMetadataIndex_LAST_CONFIG) {
+	if block.Metadata == nil || len(block.Metadata.Metadata) <= int(common.BlockMetadataIndex_SIGNATURES) {
 		return 0, errors.New("no metadata in block")
 	}
 	return utils.GetLastConfigIndexFromBlock(block)

--- a/orderer/common/cluster/util.go
+++ b/orderer/common/cluster/util.go
@@ -655,7 +655,7 @@ func LastConfigBlock(block *common.Block, blockRetriever BlockRetriever) (*commo
 	if blockRetriever == nil {
 		return nil, errors.New("nil blockRetriever")
 	}
-	if block.Metadata == nil || len(block.Metadata.Metadata) <= int(common.BlockMetadataIndex_LAST_CONFIG) {
+	if block.Metadata == nil || len(block.Metadata.Metadata) <= int(common.BlockMetadataIndex_SIGNATURES) {
 		return nil, errors.New("no metadata in block")
 	}
 	lastConfigBlockNum, err := utils.GetLastConfigIndexFromBlock(block)

--- a/orderer/common/cluster/util_test.go
+++ b/orderer/common/cluster/util_test.go
@@ -538,7 +538,11 @@ func createBlockChain(start, end uint64) []*common.Block {
 			SignatureHeader: utils.MarshalOrPanic(sHdr),
 		}
 		block.Metadata.Metadata[common.BlockMetadataIndex_SIGNATURES] = utils.MarshalOrPanic(&common.Metadata{
-			Value: nil,
+			Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{
+				LastConfig: &common.LastConfig{
+					Index: 1,
+				},
+			}),
 			Signatures: []*common.MetadataSignature{
 				blockSignature,
 			},
@@ -866,15 +870,18 @@ func TestLastConfigBlock(t *testing.T) {
 			name:           "nil metadata",
 			expectedError:  "no metadata in block",
 			blockRetriever: blockRetriever,
-			block:          &common.Block{},
+			block: &common.Block{
+				Header: &common.BlockHeader{Number: 1},
+			},
 		},
 		{
 			name:           "no last config block metadata",
 			expectedError:  "no metadata in block",
 			blockRetriever: blockRetriever,
 			block: &common.Block{
+				Header: &common.BlockHeader{Number: 1},
 				Metadata: &common.BlockMetadata{
-					Metadata: [][]byte{{}},
+					Metadata: [][]byte{},
 				},
 			},
 		},
@@ -882,18 +889,26 @@ func TestLastConfigBlock(t *testing.T) {
 			name:           "bad metadata in block",
 			blockRetriever: blockRetriever,
 			expectedError: "error unmarshaling metadata from block at index " +
-				"[LAST_CONFIG]: proto: common.Metadata: illegal tag 0 (wire type 1)",
+				"[SIGNATURES]: proto: common.Metadata: illegal tag 0 (wire type 1)",
 			block: &common.Block{
+				Header: &common.BlockHeader{Number: 1},
 				Metadata: &common.BlockMetadata{
-					Metadata: [][]byte{{}, {1, 2, 3}},
+					Metadata: [][]byte{{1, 2, 3}, {1, 2, 3}},
 				},
 			},
 		},
 		{
 			name: "no block with index",
 			block: &common.Block{
+				Header: &common.BlockHeader{Number: 1},
 				Metadata: &common.BlockMetadata{
-					Metadata: [][]byte{{}, utils.MarshalOrPanic(&common.Metadata{
+					Metadata: [][]byte{utils.MarshalOrPanic(&common.Metadata{
+						Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{
+							LastConfig: &common.LastConfig{
+								Index: 666,
+							},
+						}),
+					}), utils.MarshalOrPanic(&common.Metadata{
 						Value: utils.MarshalOrPanic(&common.LastConfig{Index: 666}),
 					})},
 				},
@@ -904,8 +919,17 @@ func TestLastConfigBlock(t *testing.T) {
 		{
 			name: "valid last config block",
 			block: &common.Block{
+				Header: &common.BlockHeader{
+					Number: 1,
+				},
 				Metadata: &common.BlockMetadata{
-					Metadata: [][]byte{{}, utils.MarshalOrPanic(&common.Metadata{
+					Metadata: [][]byte{utils.MarshalOrPanic(&common.Metadata{
+						Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{
+							LastConfig: &common.LastConfig{
+								Index: 42,
+							},
+						}),
+					}), utils.MarshalOrPanic(&common.Metadata{
 						Value: utils.MarshalOrPanic(&common.LastConfig{Index: 42}),
 					})},
 				},

--- a/orderer/common/multichannel/blockwriter_test.go
+++ b/orderer/common/multichannel/blockwriter_test.go
@@ -109,15 +109,18 @@ func TestBlockLastConfig(t *testing.T) {
 		lastConfigSeq: lastConfigSeq,
 	}
 
+	lastBlock := cb.NewBlock(newBlockNum-1, []byte("foo"))
 	block := cb.NewBlock(newBlockNum, []byte("foo"))
 	bw.addLastConfigSignature(block)
+	bw.lastBlock = lastBlock
+	bw.addBlockSignature(block)
 
 	assert.Equal(t, newBlockNum, bw.lastConfigBlockNum)
 	assert.Equal(t, newConfigSeq, bw.lastConfigSeq)
 
-	md := utils.GetMetadataFromBlockOrPanic(block, cb.BlockMetadataIndex_LAST_CONFIG)
+	md := utils.GetMetadataFromBlockOrPanic(block, cb.BlockMetadataIndex_SIGNATURES)
 	assert.NotNil(t, md.Value, "Value not be empty in this case")
-	assert.Nil(t, md.Signatures, "Should have no signatures")
+	assert.NotNil(t, md.Signatures, "Should have no signatures")
 
 	lc := utils.GetLastConfigIndexFromBlockOrPanic(block)
 	assert.Equal(t, newBlockNum, lc)

--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -84,6 +84,10 @@ func TestConfigTx(t *testing.T) {
 
 		block := blockledger.CreateNextBlock(rl, []*cb.Envelope{makeNormalTx(genesisconfig.TestChainID, 7)})
 		block.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG] = utils.MarshalOrPanic(&cb.Metadata{Value: utils.MarshalOrPanic(&cb.LastConfig{Index: 7})})
+		block.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES] = utils.MarshalOrPanic(&cb.Metadata{Value: utils.MarshalOrPanic(&cb.OrdererBlockMetadata{
+			LastConfig: &cb.LastConfig{Index: 7},
+		})})
+
 		rl.Append(block)
 
 		pctx := configTx(rl)

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -267,6 +267,9 @@ func TestExtractSysChanLastConfig(t *testing.T) {
 	nextBlock.Metadata.Metadata[common.BlockMetadataIndex_LAST_CONFIG] = utils.MarshalOrPanic(&common.Metadata{
 		Value: utils.MarshalOrPanic(&common.LastConfig{Index: rl.Height()}),
 	})
+	nextBlock.Metadata.Metadata[common.BlockMetadataIndex_SIGNATURES] = utils.MarshalOrPanic(&common.Metadata{
+		Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{LastConfig: &common.LastConfig{Index: rl.Height()}}),
+	})
 	err = rl.Append(nextBlock)
 	require.NoError(t, err)
 

--- a/orderer/common/server/onboarding_test.go
+++ b/orderer/common/server/onboarding_test.go
@@ -951,17 +951,26 @@ func TestVerifierLoader(t *testing.T) {
 			expectedPanic: "Failed retrieving block [99] for channel mychannel",
 		},
 		{
-			description:   "block retrieval succeeds but the block is bad",
-			ledgerHeight:  100,
-			lastBlock:     &common.Block{},
+			description:  "block retrieval succeeds but the block is bad",
+			ledgerHeight: 100,
+			lastBlock: &common.Block{
+				Header: &common.BlockHeader{Number: 99},
+			},
 			expectedPanic: "Failed retrieving config block [99] for channel mychannel",
 		},
 		{
 			description:  "config block retrieved is bad",
 			ledgerHeight: 100,
 			lastBlock: &common.Block{
+				Header: &common.BlockHeader{Number: 99},
 				Metadata: &common.BlockMetadata{
-					Metadata: [][]byte{{}, utils.MarshalOrPanic(&common.Metadata{
+					Metadata: [][]byte{utils.MarshalOrPanic(&common.Metadata{
+						Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{
+							LastConfig: &common.LastConfig{
+								Index: 21,
+							},
+						}),
+					}), utils.MarshalOrPanic(&common.Metadata{
 						Value: utils.MarshalOrPanic(&common.LastConfig{Index: 21}),
 					}), {}, {}},
 				},
@@ -974,8 +983,15 @@ func TestVerifierLoader(t *testing.T) {
 			description:  "VerifierFromConfig fails",
 			ledgerHeight: 100,
 			lastBlock: &common.Block{
+				Header: &common.BlockHeader{Number: 99},
 				Metadata: &common.BlockMetadata{
-					Metadata: [][]byte{{}, utils.MarshalOrPanic(&common.Metadata{
+					Metadata: [][]byte{utils.MarshalOrPanic(&common.Metadata{
+						Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{
+							LastConfig: &common.LastConfig{
+								Index: 21,
+							},
+						}),
+					}), utils.MarshalOrPanic(&common.Metadata{
 						Value: utils.MarshalOrPanic(&common.LastConfig{Index: 21}),
 					}), {}, {}},
 				},
@@ -989,8 +1005,15 @@ func TestVerifierLoader(t *testing.T) {
 			description:  "VerifierFromConfig succeeds",
 			ledgerHeight: 100,
 			lastBlock: &common.Block{
+				Header: &common.BlockHeader{Number: 99},
 				Metadata: &common.BlockMetadata{
-					Metadata: [][]byte{{}, utils.MarshalOrPanic(&common.Metadata{
+					Metadata: [][]byte{utils.MarshalOrPanic(&common.Metadata{
+						Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{
+							LastConfig: &common.LastConfig{
+								Index: 21,
+							},
+						}),
+					}), utils.MarshalOrPanic(&common.Metadata{
 						Value: utils.MarshalOrPanic(&common.LastConfig{Index: 21}),
 					}), {}, {}},
 				},

--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -3555,6 +3555,9 @@ func newChain(timeout time.Duration, channel string, dataDir string, id uint64, 
 		b.Metadata.Metadata[common.BlockMetadataIndex_LAST_CONFIG] = utils.MarshalOrPanic(&common.Metadata{
 			Value: lastConfigValue,
 		})
+		b.Metadata.Metadata[common.BlockMetadataIndex_SIGNATURES] = utils.MarshalOrPanic(&common.Metadata{
+			Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{LastConfig: &common.LastConfig{Index: c.lastConfigBlockNumber}}),
+		})
 
 		c.ledger[b.Header.Number] = b
 		if c.ledgerHeight < b.Header.Number+1 {
@@ -3578,6 +3581,9 @@ func newChain(timeout time.Duration, channel string, dataDir string, id uint64, 
 		lastConfigValue := utils.MarshalOrPanic(&common.LastConfig{Index: c.lastConfigBlockNumber})
 		b.Metadata.Metadata[common.BlockMetadataIndex_LAST_CONFIG] = utils.MarshalOrPanic(&common.Metadata{
 			Value: lastConfigValue,
+		})
+		b.Metadata.Metadata[common.BlockMetadataIndex_SIGNATURES] = utils.MarshalOrPanic(&common.Metadata{
+			Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{LastConfig: &common.LastConfig{Index: c.lastConfigBlockNumber}}),
 		})
 
 		c.ledger[b.Header.Number] = b

--- a/orderer/consensus/etcdraft/util_test.go
+++ b/orderer/consensus/etcdraft/util_test.go
@@ -162,8 +162,13 @@ func TestEndpointconfigFromFromSupport(t *testing.T) {
 		{
 			name: "Last config block cannot be retrieved",
 			blockAtHeight: &common.Block{
+				Header: &common.BlockHeader{Number: 43},
 				Metadata: &common.BlockMetadata{
-					Metadata: [][]byte{{}, utils.MarshalOrPanic(&common.Metadata{
+					Metadata: [][]byte{utils.MarshalOrPanic(&common.Metadata{
+						Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{LastConfig: &common.LastConfig{
+							Index: 42,
+						}}),
+					}), utils.MarshalOrPanic(&common.Metadata{
 						Value: utils.MarshalOrPanic(&common.LastConfig{Index: 42}),
 					})},
 				},
@@ -174,8 +179,13 @@ func TestEndpointconfigFromFromSupport(t *testing.T) {
 		{
 			name: "Last config block is retrieved but it is invalid",
 			blockAtHeight: &common.Block{
+				Header: &common.BlockHeader{Number: 43},
 				Metadata: &common.BlockMetadata{
-					Metadata: [][]byte{{}, utils.MarshalOrPanic(&common.Metadata{
+					Metadata: [][]byte{utils.MarshalOrPanic(&common.Metadata{
+						Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{LastConfig: &common.LastConfig{
+							Index: 42,
+						}}),
+					}), utils.MarshalOrPanic(&common.Metadata{
 						Value: utils.MarshalOrPanic(&common.LastConfig{Index: 42}),
 					})},
 				},
@@ -187,8 +197,13 @@ func TestEndpointconfigFromFromSupport(t *testing.T) {
 		{
 			name: "Last config block is retrieved and is valid",
 			blockAtHeight: &common.Block{
+				Header: &common.BlockHeader{Number: 43},
 				Metadata: &common.BlockMetadata{
-					Metadata: [][]byte{{}, utils.MarshalOrPanic(&common.Metadata{
+					Metadata: [][]byte{utils.MarshalOrPanic(&common.Metadata{
+						Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{LastConfig: &common.LastConfig{
+							Index: 42,
+						}}),
+					}), utils.MarshalOrPanic(&common.Metadata{
 						Value: utils.MarshalOrPanic(&common.LastConfig{Index: 42}),
 					})},
 				},
@@ -228,8 +243,13 @@ func TestNewBlockPuller(t *testing.T) {
 	assert.NoError(t, proto.Unmarshal(blockBytes, goodConfigBlock))
 
 	lastBlock := &common.Block{
+		Header: &common.BlockHeader{Number: 43},
 		Metadata: &common.BlockMetadata{
-			Metadata: [][]byte{{}, utils.MarshalOrPanic(&common.Metadata{
+			Metadata: [][]byte{utils.MarshalOrPanic(&common.Metadata{
+				Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{LastConfig: &common.LastConfig{
+					Index: 42,
+				}}),
+			}), utils.MarshalOrPanic(&common.Metadata{
 				Value: utils.MarshalOrPanic(&common.LastConfig{Index: 42}),
 			})},
 		},
@@ -378,7 +398,11 @@ func TestEvictionSuspector(t *testing.T) {
 	configBlock := &common.Block{
 		Header: &common.BlockHeader{Number: 9},
 		Metadata: &common.BlockMetadata{
-			Metadata: [][]byte{{}, {}, {}, {}},
+			Metadata: [][]byte{utils.MarshalOrPanic(&common.Metadata{
+				Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{LastConfig: &common.LastConfig{
+					Index: 9,
+				}}),
+			}), {}, {}, {}},
 		},
 	}
 	configBlock.Metadata.Metadata[common.BlockMetadataIndex_LAST_CONFIG] = utils.MarshalOrPanic(&common.Metadata{

--- a/orderer/consensus/smartbft/assembler_test.go
+++ b/orderer/consensus/smartbft/assembler_test.go
@@ -125,7 +125,13 @@ func makeNonConfigBlock(seq, lastConfigSeq uint64) *common.Block {
 			Data: [][]byte{nonConfigTx},
 		},
 		Metadata: &common.BlockMetadata{
-			Metadata: [][]byte{{},
+			Metadata: [][]byte{utils.MarshalOrPanic(&common.Metadata{
+				Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{
+					LastConfig: &common.LastConfig{
+						Index: lastConfigSeq,
+					},
+				}),
+			}),
 				utils.MarshalOrPanic(&common.Metadata{
 					Value: utils.MarshalOrPanic(&common.LastConfig{Index: lastConfigSeq}),
 				})},

--- a/orderer/consensus/smartbft/util_test.go
+++ b/orderer/consensus/smartbft/util_test.go
@@ -36,14 +36,22 @@ func TestNewBlockPuller(t *testing.T) {
 	blockBytes, err := ioutil.ReadFile("testdata/mychannel.block")
 	assert.NoError(t, err)
 
-	goodConfigBlock := &common.Block{}
+	goodConfigBlock := &common.Block{
+		Header: &common.BlockHeader{Number: 42},
+	}
 	assert.NoError(t, proto.Unmarshal(blockBytes, goodConfigBlock))
 
 	lastBlock := &common.Block{
+		Header: &common.BlockHeader{Number: 99},
 		Metadata: &common.BlockMetadata{
-			Metadata: [][]byte{{}, utils.MarshalOrPanic(&common.Metadata{
-				Value: utils.MarshalOrPanic(&common.LastConfig{Index: 42}),
-			})},
+			Metadata: [][]byte{
+				utils.MarshalOrPanic(&common.Metadata{
+					Value: utils.MarshalOrPanic(&common.OrdererBlockMetadata{
+						LastConfig: &common.LastConfig{Index: 42},
+					}),
+				}), utils.MarshalOrPanic(&common.Metadata{
+					Value: utils.MarshalOrPanic(&common.LastConfig{Index: 42}),
+				})},
 		},
 	}
 

--- a/peer/node/start.go
+++ b/peer/node/start.go
@@ -1208,6 +1208,7 @@ func (b *blockRetriever) Block(number uint64) *common2.Block {
 	if err != nil {
 		panic(err)
 	}
+	defer i.Close()
 	qr, err := i.Next()
 	if err != nil {
 		panic(err)

--- a/protos/utils/blockutils.go
+++ b/protos/utils/blockutils.go
@@ -80,16 +80,25 @@ func GetOrdererblockMetadataOrPanic(block *cb.Block) *cb.OrdererBlockMetadata {
 // GetLastConfigIndexFromBlock retrieves the index of the last config block as
 // encoded in the block metadata
 func GetLastConfigIndexFromBlock(block *cb.Block) (uint64, error) {
-	md, err := GetMetadataFromBlock(block, cb.BlockMetadataIndex_LAST_CONFIG)
+	if block == nil || block.Header == nil {
+		return 0, errors.Errorf("block is nil or header is nil")
+	}
+	if block.Header.Number == 0 {
+		return 0, nil
+	}
+	md, err := GetMetadataFromBlock(block, cb.BlockMetadataIndex_SIGNATURES)
 	if err != nil {
 		return 0, err
 	}
-	lc := &cb.LastConfig{}
-	err = proto.Unmarshal(md.Value, lc)
+	obm := &cb.OrdererBlockMetadata{}
+	err = proto.Unmarshal(md.Value, obm)
 	if err != nil {
 		return 0, errors.Wrap(err, "error unmarshaling LastConfig")
 	}
-	return lc.Index, nil
+	if obm.LastConfig == nil {
+		return 0, errors.Errorf("last config is nil")
+	}
+	return obm.LastConfig.Index, nil
 }
 
 // GetLastConfigIndexFromBlockOrPanic retrieves the index of the last config

--- a/protos/utils/blockutils_test.go
+++ b/protos/utils/blockutils_test.go
@@ -173,15 +173,15 @@ func TestCopyBlockMetadata(t *testing.T) {
 }
 
 func TestGetLastConfigIndexFromBlock(t *testing.T) {
-	block := common.NewBlock(0, nil)
+	block := common.NewBlock(1, nil)
 	index := uint64(2)
-	lc, _ := proto.Marshal(&cb.LastConfig{
-		Index: index,
+	lc, _ := proto.Marshal(&cb.OrdererBlockMetadata{
+		LastConfig: &cb.LastConfig{Index: 2},
 	})
 	metadata, _ := proto.Marshal(&cb.Metadata{
 		Value: lc,
 	})
-	block.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG] = metadata
+	block.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES] = metadata
 	result, err := utils.GetLastConfigIndexFromBlock(block)
 	assert.NoError(t, err, "Unexpected error returning last config index")
 	assert.Equal(t, index, result, "Unexpected last config index returned from block")
@@ -189,7 +189,7 @@ func TestGetLastConfigIndexFromBlock(t *testing.T) {
 	assert.Equal(t, index, result, "Unexpected last config index returned from block")
 
 	// malformed metadata
-	block.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG] = []byte("bad metadata")
+	block.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES] = []byte("bad metadata")
 	_, err = utils.GetLastConfigIndexFromBlock(block)
 	assert.Error(t, err, "Expected error with malformed metadata")
 
@@ -197,7 +197,7 @@ func TestGetLastConfigIndexFromBlock(t *testing.T) {
 	metadata, _ = proto.Marshal(&cb.Metadata{
 		Value: []byte("bad last config"),
 	})
-	block.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG] = metadata
+	block.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES] = metadata
 	_, err = utils.GetLastConfigIndexFromBlock(block)
 	assert.Error(t, err, "Expected error with malformed last config metadata")
 	assert.Panics(t, func() {


### PR DESCRIPTION
Change-Id: I9c9b459a87dbe38a2b8a60d0416ebc267c80d67b
Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>